### PR TITLE
ROO-3106: Spring Roo doesn't support new Java 7 language features

### DIFF
--- a/antlr-java-parser/pom.xml
+++ b/antlr-java-parser/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <pkgArtifactId>antlr-java-parser</pkgArtifactId>
-        <pkgVersion>1.0.3</pkgVersion>
+        <pkgVersion>1.0.5</pkgVersion>
         <osgiVersion>${pkgVersion}.0001</osgiVersion>
         <pkgVendor>Antlr Java Parser Project</pkgVendor>
         <pkgDocUrl>https://github.com/antlrjavaparser/antlr-java-parser/wiki</pkgDocUrl>


### PR DESCRIPTION
Updated version of antlrjavaparser to 1.0.5 which fixed problems with
Long literals, array creation, and constructors with parameters.
