### PR TITLE
ROO-3106: Spring Roo doesn't support new Java 7 language features

### DIFF
--- a/antlr4-runtime/pom.xml
+++ b/antlr4-runtime/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.roo</groupId>
+        <artifactId>wrapping</artifactId>
+        <version>1.1.5.RELEASE</version>
+    </parent>
+    <groupId>org.springframework.roo.wrapping</groupId>
+    <artifactId>${project.groupId}.${pkgArtifactId}</artifactId>
+    <version>${osgiVersion}</version>
+    <packaging>bundle</packaging>
+    <name>Spring Roo - Wrapping - ${pkgArtifactId}</name>
+    <description>This bundle wraps the standard Maven artifact: ${pkgArtifactId}-${pkgVersion}.</description>
+
+    <properties>
+        <pkgArtifactId>antlr4-runtime</pkgArtifactId>
+        <pkgVersion>4.0</pkgVersion>
+        <osgiVersion>${pkgVersion}.0002</osgiVersion>
+        <pkgVendor>ANTLR 4 Runtime</pkgVendor>
+        <pkgDocUrl>http://www.antlr.org/wiki/display/ANTLR4/Home</pkgDocUrl>
+        <pkgLicense>https://raw.github.com/antlr/antlr4/master/LICENSE.txt</pkgLicense>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>!org.antlr.v4.runtime.tree.gui,org.antlr.v4.runtime.*</Export-Package>
+                        <Import-Package>org.antlr.v4.runtime.tree.gui;resolution:=optional,*</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Added antlr4-runtime project as a dependency of antlr-java-parser.

I had removed this project previously, but looking back I'm not sure why.  antlr-java-parser is OSGi compliant, but antlr4-runtime is not.
