### PR TITLE
URL Cleanup

### DIFF
--- a/antlr4-runtime/pom.xml
+++ b/antlr4-runtime/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.roo</groupId>
@@ -18,7 +18,7 @@
         <pkgArtifactId>antlr4-runtime</pkgArtifactId>
         <pkgVersion>4.3</pkgVersion>
         <pkgVendor>ANTLR 4 Runtime</pkgVendor>
-        <pkgDocUrl>http://www.antlr.org/wiki/display/ANTLR4/Home</pkgDocUrl>
+        <pkgDocUrl>https://www.antlr.org/wiki/display/ANTLR4/Home</pkgDocUrl>
         <pkgLicense>https://raw.github.com/antlr/antlr4/master/LICENSE.txt</pkgLicense>
 		<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>        
     </properties>

--- a/aopalliance/pom.xml
+++ b/aopalliance/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>

--- a/bcpg-jdk15/pom.xml
+++ b/bcpg-jdk15/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,8 +18,8 @@
         <pkgArtifactId>bcpg-jdk15</pkgArtifactId>
         <pkgVersion>1.45</pkgVersion>
         <pkgVendor>Legion of the Bouncy Castle</pkgVendor>
-        <pkgDocUrl>http://www.bouncycastle.org/java.html</pkgDocUrl>
-        <pkgLicense>http://www.bouncycastle.org/licence.html</pkgLicense> <!-- "our license is an adaptation of the MIT X11 License  and should be read as such." -->
+        <pkgDocUrl>https://www.bouncycastle.org/java.html</pkgDocUrl>
+        <pkgLicense>https://www.bouncycastle.org/licence.html</pkgLicense> <!-- "our license is an adaptation of the MIT X11 License  and should be read as such." -->
     	<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/bcprov-jdk15/pom.xml
+++ b/bcprov-jdk15/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,8 +18,8 @@
         <pkgArtifactId>bcprov-jdk15</pkgArtifactId>
         <pkgVersion>1.45</pkgVersion>
         <pkgVendor>Legion of the Bouncy Castle</pkgVendor>
-        <pkgDocUrl>http://www.bouncycastle.org/java.html</pkgDocUrl>
-        <pkgLicense>http://www.bouncycastle.org/licence.html</pkgLicense> <!-- "our license is an adaptation of the MIT X11 License  and should be read as such." -->
+        <pkgDocUrl>https://www.bouncycastle.org/java.html</pkgDocUrl>
+        <pkgLicense>https://www.bouncycastle.org/licence.html</pkgLicense> <!-- "our license is an adaptation of the MIT X11 License  and should be read as such." -->
     	<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/cloud-foundry-api/pom.xml
+++ b/cloud-foundry-api/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>

--- a/commons-logging/pom.xml
+++ b/commons-logging/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -19,7 +19,7 @@
 		<pkgVersion>1.1.3</pkgVersion>
 		<osgiVersion>${pkgVersion}.0002</osgiVersion>
 		<pkgVendor>Apache Commons Logging</pkgVendor>
-		<pkgDocUrl>http://commons.apache.org/proper/commons-logging/</pkgDocUrl>
+		<pkgDocUrl>https://commons.apache.org/proper/commons-logging/</pkgDocUrl>
 		<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
 	</properties>
 

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -24,7 +24,7 @@
         <repository>
           <id>maven2-repository.dev.java.net</id>
           <name>Java.net Repository for Maven</name>
-          <url>http://download.java.net/maven/2/</url>
+          <url>https://download.java.net/maven/2/</url>
           <layout>default</layout>
         </repository>
     </repositories>

--- a/db2express/db2jcc4/pom.xml
+++ b/db2express/db2jcc4/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springframework.roo.wrapping</groupId>
@@ -20,8 +20,8 @@
         <pkgVersion>9.7.2</pkgVersion>
         <osgiVersion>${pkgVersion}.0011</osgiVersion>
         <pkgVendor>IBM</pkgVendor>
-        <pkgDocUrl>http://www-01.ibm.com/software/data/db2/express/</pkgDocUrl>
-        <pkgLicense>http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&amp;li_formnum=L-CLAW-7QANPG&amp;title=DB2+Express-C+database+server&amp;l=en</pkgLicense>
+        <pkgDocUrl>https://www-01.ibm.com/software/data/db2/express/</pkgDocUrl>
+        <pkgLicense>https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&amp;li_formnum=L-CLAW-7QANPG&amp;title=DB2+Express-C+database+server&amp;l=en</pkgLicense>
     	<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/db2express/pom.xml
+++ b/db2express/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
 	<groupId>org.springframework.roo</groupId>

--- a/derby-client/pom.xml
+++ b/derby-client/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,8 +18,8 @@
         <pkgArtifactId>derbyclient</pkgArtifactId>
         <pkgVersion>10.8.2.2</pkgVersion>
         <pkgVendor>Apache Derby</pkgVendor>
-        <pkgDocUrl>http://db.apache.org/derby/</pkgDocUrl>
-        <pkgLicense>http://db.apache.org/derby/license.html</pkgLicense> 
+        <pkgDocUrl>https://db.apache.org/derby/</pkgDocUrl>
+        <pkgLicense>https://db.apache.org/derby/license.html</pkgLicense> 
     	<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/derby/pom.xml
+++ b/derby/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,8 +18,8 @@
         <pkgArtifactId>derby</pkgArtifactId>
         <pkgVersion>10.8.2.2</pkgVersion>
         <pkgVendor>Apache Derby</pkgVendor>
-        <pkgDocUrl>http://db.apache.org/derby/</pkgDocUrl>
-        <pkgLicense>http://db.apache.org/derby/license.html</pkgLicense> 
+        <pkgDocUrl>https://db.apache.org/derby/</pkgDocUrl>
+        <pkgLicense>https://db.apache.org/derby/license.html</pkgLicense> 
     	<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/felix-framework/pom.xml
+++ b/felix-framework/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.roo.wrapping</groupId>
     <artifactId>${project.groupId}.${pkgArtifactId}</artifactId>
@@ -13,8 +13,8 @@
         <pkgArtifactId>org.apache.felix.framework</pkgArtifactId>
         <pkgVersion>5.2.0</pkgVersion>
         <pkgVendor>The Apache Software Foundation</pkgVendor>
-        <pkgDocUrl>http://felix.apache.org/documentation.html</pkgDocUrl>
-        <pkgLicense>http://felix.apache.org/license.html</pkgLicense>
+        <pkgDocUrl>https://felix.apache.org/documentation.html</pkgDocUrl>
+        <pkgLicense>https://felix.apache.org/license.html</pkgLicense>
         <target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/felix-http-jetty/pom.xml
+++ b/felix-http-jetty/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.roo.wrapping</groupId>
     <artifactId>${project.groupId}.${pkgArtifactId}</artifactId>
@@ -13,8 +13,8 @@
         <pkgArtifactId>org.apache.felix.http.jetty</pkgArtifactId>
         <pkgVersion>2.3.2</pkgVersion>
         <pkgVendor>The Apache Software Foundation</pkgVendor>
-        <pkgDocUrl>http://felix.apache.org/documentation.html</pkgDocUrl>
-        <pkgLicense>http://felix.apache.org/license.html</pkgLicense>
+        <pkgDocUrl>https://felix.apache.org/documentation.html</pkgDocUrl>
+        <pkgLicense>https://felix.apache.org/license.html</pkgLicense>
         <target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/firebird/pom.xml
+++ b/firebird/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,8 +18,8 @@
         <pkgArtifactId>firebird</pkgArtifactId>
         <pkgVersion>2.1.6</pkgVersion>
         <pkgVendor>The Firebird Project</pkgVendor>
-        <pkgDocUrl>http://www.firebirdsql.org/</pkgDocUrl>
-        <pkgLicense><![CDATA[http://www.firebirdsql.org/index.php?op=doc&amp;id=idpl]]></pkgLicense> 
+        <pkgDocUrl>https://www.firebirdsql.org/</pkgDocUrl>
+        <pkgLicense><![CDATA[https://www.firebirdsql.org/index.php?op=doc&amp;id=idpl]]></pkgLicense> 
     	<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,8 +18,8 @@
         <pkgVersion>1.3.164</pkgVersion>
         <osgiVersion>${pkgVersion}.0002</osgiVersion>
         <pkgVendor>H2 Database Engine</pkgVendor>
-        <pkgDocUrl>http://www.h2database.com</pkgDocUrl>
-        <pkgLicense>http://www.h2database.com/html/license.html</pkgLicense> 
+        <pkgDocUrl>https://www.h2database.com</pkgDocUrl>
+        <pkgLicense>https://www.h2database.com/html/license.html</pkgLicense> 
     	<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/hapax/pom.xml
+++ b/hapax/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,8 +18,8 @@
         <pkgVersion>2.3.4</pkgVersion>
         <osgiVersion>${pkgVersion}.0010</osgiVersion>
         <pkgVendor>The Hapax2 Project</pkgVendor>
-        <pkgDocUrl>http://code.google.com/p/hapax2/</pkgDocUrl>
-        <pkgLicense>http://www.opensource.org/licenses/mit-license.php</pkgLicense>
+        <pkgDocUrl>https://code.google.com/p/hapax2/</pkgDocUrl>
+        <pkgLicense>https://www.opensource.org/licenses/mit-license.php</pkgLicense>
     	<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/hsqldb/pom.xml
+++ b/hsqldb/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>

--- a/inflector/pom.xml
+++ b/inflector/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>

--- a/javaparser/pom.xml
+++ b/javaparser/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,8 +18,8 @@
         <pkgVersion>1.0.7</pkgVersion>
         <osgiVersion>${pkgVersion}.0011</osgiVersion>
         <pkgVendor>JavaParser Project</pkgVendor>
-        <pkgDocUrl>http://code.google.com/p/javaparser/</pkgDocUrl>
-        <pkgLicense>http://www.gnu.org/licenses/lgpl.html</pkgLicense>
+        <pkgDocUrl>https://code.google.com/p/javaparser/</pkgDocUrl>
+        <pkgLicense>https://www.gnu.org/licenses/lgpl.html</pkgLicense>
     	<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/javax-el/pom.xml
+++ b/javax-el/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>

--- a/javax-inject/pom.xml
+++ b/javax-inject/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>

--- a/jgit/pom.xml
+++ b/jgit/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,15 +18,15 @@
         <pkgVersion>0.12.1</pkgVersion>
         <osgiVersion>${pkgVersion}.0011</osgiVersion>
         <pkgVendor>The JGit Project</pkgVendor>
-        <pkgDocUrl>http://www.eclipse.org/jgit/</pkgDocUrl>
-        <pkgLicense>http://www.eclipse.org/org/documents/edl-v10.php</pkgLicense> 
+        <pkgDocUrl>https://www.eclipse.org/jgit/</pkgDocUrl>
+        <pkgLicense>https://www.eclipse.org/org/documents/edl-v10.php</pkgLicense> 
     	<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 
 	<repositories>
 	  <repository>
 	    <id>jgit-repository</id>
-	    <url>http://download.eclipse.org/jgit/maven</url>
+	    <url>https://download.eclipse.org/jgit/maven</url>
       </repository>
 	</repositories>
 

--- a/jline/pom.xml
+++ b/jline/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -17,7 +17,7 @@
 		<repository>
 	  	    <id>springsource-repository-release</id>
 		    <name>libs-release</name>
-		    <url>http://repo.springsource.org/libs-release</url>
+		    <url>https://repo.springsource.org/libs-release</url>
 		    <snapshots>
 	    	    	<enabled>false</enabled>
 	  	    </snapshots>
@@ -30,7 +30,7 @@
         <osgiVersion>${pkgVersion}.0013</osgiVersion>
         <pkgVendor>JLine Project</pkgVendor>
         <pkgDocUrl>http://jline.sourceforge.net/</pkgDocUrl>
-        <pkgLicense>http://www.opensource.org/licenses/bsd-license.php</pkgLicense>
+        <pkgLicense>https://www.opensource.org/licenses/bsd-license.php</pkgLicense>
     	<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/jsch/pom.xml
+++ b/jsch/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>

--- a/json-simple/pom.xml
+++ b/json-simple/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,7 +18,7 @@
         <pkgArtifactId>json-simple</pkgArtifactId>
         <pkgVersion>1.1</pkgVersion>
         <pkgVendor>JSON-Simple Project</pkgVendor>
-        <pkgDocUrl>http://code.google.com/p/json-simple/</pkgDocUrl>
+        <pkgDocUrl>https://code.google.com/p/json-simple/</pkgDocUrl>
         <pkgLicense>http://www.apache.org/licenses/LICENSE-2.0.html</pkgLicense>
         <target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>

--- a/jsoup/pom.xml
+++ b/jsoup/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>

--- a/jtds/pom.xml
+++ b/jtds/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>

--- a/jtopen/pom.xml
+++ b/jtopen/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -19,7 +19,7 @@
         <pkgVersion>6.7</pkgVersion>
         <pkgVendor>The JTOpen Project</pkgVendor>
         <pkgDocUrl>http://jt400.sourceforge.net/</pkgDocUrl>
-        <pkgLicense>http://www.opensource.org/licenses/ibmpl.php</pkgLicense> 
+        <pkgLicense>https://www.opensource.org/licenses/ibmpl.php</pkgLicense> 
         <target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/mysql/pom.xml
+++ b/mysql/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,8 +18,8 @@
         <pkgArtifactId>mysql-connector-java</pkgArtifactId>
         <pkgVersion>5.1.18</pkgVersion>
         <pkgVendor>MySQL</pkgVendor>
-        <pkgDocUrl>http://www.mysql.com/</pkgDocUrl>
-        <pkgLicense>http://www.mysql.com/about/legal/licensing/oem/</pkgLicense> <!-- Based on GPL license -->
+        <pkgDocUrl>https://www.mysql.com/</pkgDocUrl>
+        <pkgLicense>https://www.mysql.com/about/legal/licensing/oem/</pkgLicense> <!-- Based on GPL license -->
     	<target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/oracle/ojdbc14/pom.xml
+++ b/oracle/ojdbc14/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springframework.roo.wrapping</groupId>
@@ -19,8 +19,8 @@
     <pkgArtifactId>ojdbc14</pkgArtifactId>
     <pkgVersion>${project.version}</pkgVersion>
     <pkgVendor>Oracle Corporation</pkgVendor>
-    <pkgDocUrl>http://www.oracle.com/technology/software/tech/java/sqlj_jdbc/index.html</pkgDocUrl>
-    <pkgLicense>http://www.oracle.com/technology/software/htdocs/distlic.html</pkgLicense>
+    <pkgDocUrl>https://www.oracle.com/technology/software/tech/java/sqlj_jdbc/index.html</pkgDocUrl>
+    <pkgLicense>https://www.oracle.com/technology/software/htdocs/distlic.html</pkgLicense>
     <pkgExport>*;version=${pkgVersion}</pkgExport>
     <pkgImport>*;resolution:=optional</pkgImport>
     <pkgPrivate>!*</pkgPrivate>

--- a/oracle/ojdbc6/pom.xml
+++ b/oracle/ojdbc6/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springframework.roo.wrapping</groupId>
@@ -18,8 +18,8 @@
     <pkgArtifactId>ojdbc6</pkgArtifactId>
     <pkgVersion>${project.version}</pkgVersion>
     <pkgVendor>Oracle Corporation</pkgVendor>
-    <pkgDocUrl>http://www.oracle.com/technology/software/tech/java/sqlj_jdbc/index.html</pkgDocUrl>
-    <pkgLicense>http://www.oracle.com/technology/software/htdocs/distlic.html</pkgLicense>
+    <pkgDocUrl>https://www.oracle.com/technology/software/tech/java/sqlj_jdbc/index.html</pkgDocUrl>
+    <pkgLicense>https://www.oracle.com/technology/software/htdocs/distlic.html</pkgLicense>
     <pkgExport>*;version=${pkgVersion}</pkgExport>
     <pkgImport>*;resolution:=optional</pkgImport>
     <pkgPrivate>!*</pkgPrivate>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
 	<groupId>org.springframework.roo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.roo</groupId>
     <version>2.0.0.RELEASE</version>
@@ -14,12 +14,12 @@
 	    <repository>
 	        <id>wrapping-repo</id>
 	        <name>repo.spring.io-releases</name>
-    	    <url>http://repo.spring.io/spring-roo</url>
+    	    <url>https://repo.spring.io/spring-roo</url>
 	    </repository>
 	    <snapshotRepository>
 	        <id>wrapping-repo-snapshots</id>
 	        <name>repo.spring.io-snapshots</name>
-    	    <url>http://repo.spring.io/spring-roo/snapshots</url>
+    	    <url>https://repo.spring.io/spring-roo/snapshots</url>
 	    </snapshotRepository>
 	</distributionManagement>
 
@@ -70,7 +70,7 @@
         <repository>
             <id>maven.springframework.org.external</id>
             <name>SpringSource Maven Repository - External Releases</name>
-            <url>http://maven.springframework.org/external</url>
+            <url>https://maven.springframework.org/external</url>
         </repository>
     </repositories>
 
@@ -78,12 +78,12 @@
         <pluginRepository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </pluginRepository>
 	    <pluginRepository>
 	      <id>atlassian-maven-release</id>
 	      <name>Atlassian Maven Release Repository</name>
-	      <url>http://maven.atlassian.com/repository/public</url>
+	      <url>https://maven.atlassian.com/repository/public</url>
 	    </pluginRepository>
     </pluginRepositories>
 

--- a/postgresql/pom.xml
+++ b/postgresql/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,8 +18,8 @@
         <pkgArtifactId>postgresql</pkgArtifactId>
         <pkgVersion>9.1-901</pkgVersion>
         <pkgVendor>The PostgreSQL Global Development Group</pkgVendor>
-        <pkgDocUrl>http://jdbc.postgresql.org/</pkgDocUrl>
-        <pkgLicense>http://jdbc.postgresql.org/license.html</pkgLicense> <!-- It's the BSD license -->
+        <pkgDocUrl>https://jdbc.postgresql.org/</pkgDocUrl>
+        <pkgLicense>https://jdbc.postgresql.org/license.html</pkgLicense> <!-- It's the BSD license -->
         <target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/protobuf-full/pom.xml
+++ b/protobuf-full/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,8 +18,8 @@
         <pkgVersion>2.4.1</pkgVersion>
         <osgiVersion>${pkgVersion}.0011</osgiVersion>
         <pkgVendor>Google Inc</pkgVendor>
-        <pkgDocUrl>http://code.google.com/p/protobuf</pkgDocUrl>
-        <pkgLicense>http://www.opensource.org/licenses/bsd-license.php</pkgLicense>
+        <pkgDocUrl>https://code.google.com/p/protobuf</pkgDocUrl>
+        <pkgLicense>https://www.opensource.org/licenses/bsd-license.php</pkgLicense>
         <target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/protobuf-lite/pom.xml
+++ b/protobuf-lite/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>
@@ -18,8 +18,8 @@
         <pkgVersion>2.4.1</pkgVersion>
         <osgiVersion>${pkgVersion}.0011</osgiVersion>
         <pkgVendor>Google Inc</pkgVendor>
-        <pkgDocUrl>http://code.google.com/p/protobuf</pkgDocUrl>
-        <pkgLicense>http://www.opensource.org/licenses/bsd-license.php</pkgLicense>
+        <pkgDocUrl>https://code.google.com/p/protobuf</pkgDocUrl>
+        <pkgLicense>https://www.opensource.org/licenses/bsd-license.php</pkgLicense>
         <target.osgi-repository.directory>${basedir}/../target/osgi-repository-bin</target.osgi-repository.directory>
     </properties>
 

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <licenses>
         <license>
             <name>&gt;GNU General Public License (GPL), Version 3.0</name>
-            <url>http://www.gnu.org/copyleft/gpl.html</url>
+            <url>https://www.gnu.org/copyleft/gpl.html</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -162,7 +162,7 @@
             </goals>
             <configuration>
               <serverId>wrapping-repo</serverId>
-              <url>http://repo.spring.io/spring-roo</url>
+              <url>https://repo.spring.io/spring-roo</url>
               <fromDir>../target/osgi-repository-bin</fromDir>
               <toDir>/</toDir>
               <includes>index.xml</includes>

--- a/snakeyaml/pom.xml
+++ b/snakeyaml/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.roo</groupId>

--- a/src/main/assembly/repo-assembly.xml
+++ b/src/main/assembly/repo-assembly.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 https://maven.apache.org/xsd/assembly-1.1.2.xsd">
   <id>bin</id>
   <formats>
     <format>dir</format>
@@ -37,7 +37,7 @@
      </includes>
 
       <!-- Customizing Dependency Output Location 
-           http://books.sonatype.com/mvnref-book/reference/assemblies-sect-controlling-contents.html
+           https://books.sonatype.com/mvnref-book/reference/assemblies-sect-controlling-contents.html
       -->
 
       <binaries>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://aopalliance.sourceforge.net/ (200) with 2 occurrences could not be migrated:  
   ([https](https://aopalliance.sourceforge.net/) result AnnotatedConnectException).
* http://hsqldb.org/ (200) with 1 occurrences could not be migrated:  
   ([https](https://hsqldb.org/) result SSLHandshakeException).
* http://hsqldb.org/web/hsqlLicense.html (200) with 1 occurrences could not be migrated:  
   ([https](https://hsqldb.org/web/hsqlLicense.html) result SSLHandshakeException).
* http://jline.sourceforge.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://jline.sourceforge.net/) result AnnotatedConnectException).
* http://jt400.sourceforge.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://jt400.sourceforge.net/) result AnnotatedConnectException).
* http://jtds.sourceforge.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://jtds.sourceforge.net/) result AnnotatedConnectException).
* http://jtds.sourceforge.net/license.html (200) with 1 occurrences could not be migrated:  
   ([https](https://jtds.sourceforge.net/license.html) result AnnotatedConnectException).
* http://www.jcraft.com/jsch/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.jcraft.com/jsch/) result AnnotatedConnectException).
* http://www.jcraft.com/jsch/LICENSE.txt (200) with 1 occurrences could not be migrated:  
   ([https](https://www.jcraft.com/jsch/LICENSE.txt) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://download.java.net/maven/2/ (301) with 1 occurrences migrated to:  
  https://download.java.net/maven/2/ ([https](https://download.java.net/maven/2/) result 404).
* http://jdbc.postgresql.org/license.html (301) with 1 occurrences migrated to:  
  https://jdbc.postgresql.org/license.html ([https](https://jdbc.postgresql.org/license.html) result 404).
* http://maven.springframework.org/external (404) with 1 occurrences migrated to:  
  https://maven.springframework.org/external ([https](https://maven.springframework.org/external) result 404).
* http://repo.spring.io/spring-roo/snapshots (404) with 1 occurrences migrated to:  
  https://repo.spring.io/spring-roo/snapshots ([https](https://repo.spring.io/spring-roo/snapshots) result 404).
* http://www.antlr.org/wiki/display/ANTLR4/Home (301) with 1 occurrences migrated to:  
  https://www.antlr.org/wiki/display/ANTLR4/Home ([https](https://www.antlr.org/wiki/display/ANTLR4/Home) result 404).
* http://www.oracle.com/technology/software/htdocs/distlic.html (301) with 2 occurrences migrated to:  
  https://www.oracle.com/technology/software/htdocs/distlic.html ([https](https://www.oracle.com/technology/software/htdocs/distlic.html) result 404).
* http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&amp;li_formnum=L-CLAW-7QANPG&amp;title=DB2+Express-C+database+server&amp;l=en (500) with 1 occurrences migrated to:  
  https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&amp;li_formnum=L-CLAW-7QANPG&amp;title=DB2+Express-C+database+server&amp;l=en ([https](https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&amp;li_formnum=L-CLAW-7QANPG&amp;title=DB2+Express-C+database+server&amp;l=en) result 500).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://books.sonatype.com/mvnref-book/reference/assemblies-sect-controlling-contents.html with 1 occurrences migrated to:  
  https://books.sonatype.com/mvnref-book/reference/assemblies-sect-controlling-contents.html ([https](https://books.sonatype.com/mvnref-book/reference/assemblies-sect-controlling-contents.html) result 200).
* http://commons.apache.org/proper/commons-logging/ with 1 occurrences migrated to:  
  https://commons.apache.org/proper/commons-logging/ ([https](https://commons.apache.org/proper/commons-logging/) result 200).
* http://db.apache.org/derby/ with 2 occurrences migrated to:  
  https://db.apache.org/derby/ ([https](https://db.apache.org/derby/) result 200).
* http://db.apache.org/derby/license.html with 2 occurrences migrated to:  
  https://db.apache.org/derby/license.html ([https](https://db.apache.org/derby/license.html) result 200).
* http://felix.apache.org/documentation.html with 2 occurrences migrated to:  
  https://felix.apache.org/documentation.html ([https](https://felix.apache.org/documentation.html) result 200).
* http://felix.apache.org/license.html with 2 occurrences migrated to:  
  https://felix.apache.org/license.html ([https](https://felix.apache.org/license.html) result 200).
* http://jdbc.postgresql.org/ with 1 occurrences migrated to:  
  https://jdbc.postgresql.org/ ([https](https://jdbc.postgresql.org/) result 200).
* http://maven.apache.org/xsd/assembly-1.1.2.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/assembly-1.1.2.xsd ([https](https://maven.apache.org/xsd/assembly-1.1.2.xsd) result 200).
* http://www.bouncycastle.org/java.html with 2 occurrences migrated to:  
  https://www.bouncycastle.org/java.html ([https](https://www.bouncycastle.org/java.html) result 200).
* http://www.bouncycastle.org/licence.html with 2 occurrences migrated to:  
  https://www.bouncycastle.org/licence.html ([https](https://www.bouncycastle.org/licence.html) result 200).
* http://www.eclipse.org/jgit/ with 1 occurrences migrated to:  
  https://www.eclipse.org/jgit/ ([https](https://www.eclipse.org/jgit/) result 200).
* http://www.eclipse.org/org/documents/edl-v10.php with 1 occurrences migrated to:  
  https://www.eclipse.org/org/documents/edl-v10.php ([https](https://www.eclipse.org/org/documents/edl-v10.php) result 200).
* http://www.firebirdsql.org/ with 1 occurrences migrated to:  
  https://www.firebirdsql.org/ ([https](https://www.firebirdsql.org/) result 200).
* http://www.gnu.org/copyleft/gpl.html with 1 occurrences migrated to:  
  https://www.gnu.org/copyleft/gpl.html ([https](https://www.gnu.org/copyleft/gpl.html) result 200).
* http://www.gnu.org/licenses/lgpl.html with 1 occurrences migrated to:  
  https://www.gnu.org/licenses/lgpl.html ([https](https://www.gnu.org/licenses/lgpl.html) result 200).
* http://www.h2database.com with 1 occurrences migrated to:  
  https://www.h2database.com ([https](https://www.h2database.com) result 200).
* http://www.h2database.com/html/license.html with 1 occurrences migrated to:  
  https://www.h2database.com/html/license.html ([https](https://www.h2database.com/html/license.html) result 200).
* http://www.mysql.com/ with 1 occurrences migrated to:  
  https://www.mysql.com/ ([https](https://www.mysql.com/) result 200).
* http://www.mysql.com/about/legal/licensing/oem/ with 1 occurrences migrated to:  
  https://www.mysql.com/about/legal/licensing/oem/ ([https](https://www.mysql.com/about/legal/licensing/oem/) result 200).
* http://code.google.com/p/hapax2/ with 1 occurrences migrated to:  
  https://code.google.com/p/hapax2/ ([https](https://code.google.com/p/hapax2/) result 301).
* http://code.google.com/p/javaparser/ with 1 occurrences migrated to:  
  https://code.google.com/p/javaparser/ ([https](https://code.google.com/p/javaparser/) result 301).
* http://code.google.com/p/json-simple/ with 1 occurrences migrated to:  
  https://code.google.com/p/json-simple/ ([https](https://code.google.com/p/json-simple/) result 301).
* http://code.google.com/p/protobuf with 2 occurrences migrated to:  
  https://code.google.com/p/protobuf ([https](https://code.google.com/p/protobuf) result 301).
* http://download.eclipse.org/jgit/maven with 1 occurrences migrated to:  
  https://download.eclipse.org/jgit/maven ([https](https://download.eclipse.org/jgit/maven) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 38 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://repo.springsource.org/libs-release with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-release ([https](https://repo.springsource.org/libs-release) result 301).
* http://www-01.ibm.com/software/data/db2/express/ with 1 occurrences migrated to:  
  https://www-01.ibm.com/software/data/db2/express/ ([https](https://www-01.ibm.com/software/data/db2/express/) result 301).
* http://www.firebirdsql.org/index.php?op=doc&amp;id=idpl with 1 occurrences migrated to:  
  https://www.firebirdsql.org/index.php?op=doc&amp;id=idpl ([https](https://www.firebirdsql.org/index.php?op=doc&amp;id=idpl) result 301).
* http://www.opensource.org/licenses/bsd-license.php with 3 occurrences migrated to:  
  https://www.opensource.org/licenses/bsd-license.php ([https](https://www.opensource.org/licenses/bsd-license.php) result 301).
* http://www.opensource.org/licenses/ibmpl.php with 1 occurrences migrated to:  
  https://www.opensource.org/licenses/ibmpl.php ([https](https://www.opensource.org/licenses/ibmpl.php) result 301).
* http://www.opensource.org/licenses/mit-license.php with 1 occurrences migrated to:  
  https://www.opensource.org/licenses/mit-license.php ([https](https://www.opensource.org/licenses/mit-license.php) result 301).
* http://www.oracle.com/technology/software/tech/java/sqlj_jdbc/index.html with 2 occurrences migrated to:  
  https://www.oracle.com/technology/software/tech/java/sqlj_jdbc/index.html ([https](https://www.oracle.com/technology/software/tech/java/sqlj_jdbc/index.html) result 301).
* http://maven.atlassian.com/repository/public with 1 occurrences migrated to:  
  https://maven.atlassian.com/repository/public ([https](https://maven.atlassian.com/repository/public) result 302).
* http://maven.springframework.org/release with 1 occurrences migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://repo.spring.io/spring-roo with 2 occurrences migrated to:  
  https://repo.spring.io/spring-roo ([https](https://repo.spring.io/spring-roo) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 76 occurrences
* http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 39 occurrences