### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ The output JAR is then usable in Roo or other OSGi containers
 == Prerequisites
 
 In order to complete these instructions, you must have rights to
-deploy files to http://repo.spring.io/spring-roo/.
+deploy files to https://repo.spring.io/spring-roo/.
 
 All wrapped JARs are deployed under the following directory:
 
@@ -36,7 +36,7 @@ To perform wrapping you need:
 * GPG setup (see main Spring Roo readme.txt for instructions)
  
 If you want to host an OSGi-compliant JAR that
-does not need wrapping at http://repo.spring.io/spring-roo/,
+does not need wrapping at https://repo.spring.io/spring-roo/,
 be sure to create an .ASC file of the JAR and _pom.xml_ using 
 `gpg --ab <filename>` and upload the ASC files as well.
 
@@ -79,6 +79,6 @@ everyone is on the latest release you have made.
 
 If you have general questions on Roo's wrapping approach, please use
 the Stackoverflow. You can access it at
-http://stackoverflow.com/questions/tagged/spring-roo. Thanks for your
+https://stackoverflow.com/questions/tagged/spring-roo. Thanks for your
 interest in Spring Roo!
 

--- a/db2express/readme.txt
+++ b/db2express/readme.txt
@@ -1,3 +1,3 @@
 
-Db2Express JDBC driver must be downloaded manually from http://www-01.ibm.com/support/docview.wss?uid=swg21363866 before build the wrapping.
+Db2Express JDBC driver must be downloaded manually from https://www-01.ibm.com/support/docview.wss?uid=swg21363866 before build the wrapping.
 Read db2jcc4/readme.txt for more information.

--- a/oracle/ojdbc14/readme.txt
+++ b/oracle/ojdbc14/readme.txt
@@ -1,5 +1,5 @@
 
-Oracle JDBC driver must be downloaded manually from http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html before build the wrapping.
+Oracle JDBC driver must be downloaded manually from https://www.oracle.com/technetwork/database/features/jdbc/index-091264.html before build the wrapping.
 Wrapping is internally configured for use com.oracle.ojdbc14 10.2.0.5 driver, use another at your own risk.
 Then run lib/install-lib.sh to install the driver in your maven local repository.
 Finally build the wrapping with maven.

--- a/oracle/ojdbc6/readme.txt
+++ b/oracle/ojdbc6/readme.txt
@@ -1,5 +1,5 @@
 
-Oracle JDBC driver must be downloaded manually from http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html before build the wrapping.
+Oracle JDBC driver must be downloaded manually from https://www.oracle.com/technetwork/database/features/jdbc/index-091264.html before build the wrapping.
 Wrapping is internally configured for use com.oracle.ojdbc6 11.2.0.3 driver, use another at your own risk.
 Then run lib/install-lib.sh to install the driver in your maven local repository.
 Finally build the wrapping with maven.

--- a/oracle/readme.txt
+++ b/oracle/readme.txt
@@ -1,3 +1,3 @@
 
-Oracle JDBC driver must be downloaded manually from http://www.oracle.com/technetwork/database/features/jdbc before build the wrapping.
+Oracle JDBC driver must be downloaded manually from https://www.oracle.com/technetwork/database/features/jdbc before build the wrapping.
 Read ojdbc14/readme.txt or ojdbc6/readme.txt for more information.

--- a/repository/src/main/resources/obr2html.xsl
+++ b/repository/src/main/resources/obr2html.xsl
@@ -84,7 +84,7 @@
 	  
 			<div class="inner">
 			    <div class="container">
-			    	<a class="brand light" href="http://projects.spring.io/spring-roo" role="banner" itemprop="url">
+			    	<a class="brand light" href="https://projects.spring.io/spring-roo" role="banner" itemprop="url">
 			    		<img itemprop="logo" src="https://projects.spring.io/spring-roo/img/project-icon-large.png" alt="Spring Roo Logo" />
 			    	</a>
 			    	<h2 class="light" itemprop="description">
@@ -115,7 +115,7 @@
 	                  Spring Roo © 2015 
 	                </p>
 	                <p class="rss-subscribe text-center">
-	                 <a data-original-title="Spring Roo Project Page" href="http://projects.spring.io/spring-roo/" target="_blank" data-toggle="tooltip" title="">Spring Roo</a>
+	                 <a data-original-title="Spring Roo Project Page" href="https://projects.spring.io/spring-roo/" target="_blank" data-toggle="tooltip" title="">Spring Roo</a>
 	                </p>
 	            </div>
 	        </div>

--- a/repository/src/main/resources/style.css
+++ b/repository/src/main/resources/style.css
@@ -1,9 +1,9 @@
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,700);
-@import url(http://fonts.googleapis.com/css?family=Merriweather:400,300,400italic,700);
+@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,700);
+@import url(https://fonts.googleapis.com/css?family=Merriweather:400,300,400italic,700);
 
 /** custom font **/
-@import url(http://fonts.googleapis.com/css?family=Montserrat:700,400);
-@import url(http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic);
+@import url(https://fonts.googleapis.com/css?family=Montserrat:700,400);
+@import url(https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic);
 
 @import url( home.css);
 @import url( projects.css.css);


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic with 1 occurrences migrated to:  
  https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic ([https](https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic) result 200).
* [ ] http://fonts.googleapis.com/css?family=Merriweather:400,300,400italic,700 with 1 occurrences migrated to:  
  https://fonts.googleapis.com/css?family=Merriweather:400,300,400italic,700 ([https](https://fonts.googleapis.com/css?family=Merriweather:400,300,400italic,700) result 200).
* [ ] http://fonts.googleapis.com/css?family=Montserrat:700,400 with 1 occurrences migrated to:  
  https://fonts.googleapis.com/css?family=Montserrat:700,400 ([https](https://fonts.googleapis.com/css?family=Montserrat:700,400) result 200).
* [ ] http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,700 with 1 occurrences migrated to:  
  https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,700 ([https](https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,700) result 200).
* [ ] http://projects.spring.io/spring-roo/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-roo/ ([https](https://projects.spring.io/spring-roo/) result 200).
* [ ] http://repo.spring.io/spring-roo/ with 2 occurrences migrated to:  
  https://repo.spring.io/spring-roo/ ([https](https://repo.spring.io/spring-roo/) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-roo with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-roo ([https](https://stackoverflow.com/questions/tagged/spring-roo) result 200).
* [ ] http://www-01.ibm.com/support/docview.wss?uid=swg21363866 with 1 occurrences migrated to:  
  https://www-01.ibm.com/support/docview.wss?uid=swg21363866 ([https](https://www-01.ibm.com/support/docview.wss?uid=swg21363866) result 200).
* [ ] http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html with 2 occurrences migrated to:  
  https://www.oracle.com/technetwork/database/features/jdbc/index-091264.html ([https](https://www.oracle.com/technetwork/database/features/jdbc/index-091264.html) result 200).
* [ ] http://projects.spring.io/spring-roo with 1 occurrences migrated to:  
  https://projects.spring.io/spring-roo ([https](https://projects.spring.io/spring-roo) result 301).
* [ ] http://www.oracle.com/technetwork/database/features/jdbc with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/database/features/jdbc ([https](https://www.oracle.com/technetwork/database/features/jdbc) result 301).

# Ignored
These URLs were intentionally ignored.

* http://www.w3.org/1999/XSL/Transform with 1 occurrences